### PR TITLE
sensors4 use sdf10

### DIFF
--- a/ign-sensors4.yaml
+++ b/ign-sensors4.yaml
@@ -34,4 +34,4 @@ repositories:
   sdformat:
     type: git
     url: https://github.com/osrf/sdformat
-    version: master
+    version: sdf10


### PR DESCRIPTION
Fixes CI for https://github.com/ignitionrobotics/ign-sensors/pull/31

Current SDFormat `master` is version 11.