### PR TITLE
Update Dome branches

### DIFF
--- a/collection-dome.yaml
+++ b/collection-dome.yaml
@@ -10,19 +10,19 @@ repositories:
   ign-fuel-tools:
     type: git
     url: https://github.com/ignitionrobotics/ign-fuel-tools
-    version: master
+    version: ign-fuel-tools5
   ign-gazebo:
     type: git
     url: https://github.com/ignitionrobotics/ign-gazebo
-    version: master
+    version: ign-gazebo4
   ign-gui:
     type: git
     url: https://github.com/ignitionrobotics/ign-gui
-    version: master
+    version: ign-gui4
   ign-launch:
     type: git
     url: https://github.com/ignitionrobotics/ign-launch
-    version: master
+    version: ign-launch3
   ign-math:
     type: git
     url: https://github.com/ignitionrobotics/ign-math
@@ -30,11 +30,11 @@ repositories:
   ign-msgs:
     type: git
     url: https://github.com/ignitionrobotics/ign-msgs
-    version: master
+    version: ign-msgs6
   ign-physics:
     type: git
     url: https://github.com/ignitionrobotics/ign-physics
-    version: master
+    version: ign-physics3
   ign-plugin:
     type: git
     url: https://github.com/ignitionrobotics/ign-plugin
@@ -42,11 +42,11 @@ repositories:
   ign-rendering:
     type: git
     url: https://github.com/ignitionrobotics/ign-rendering
-    version: master
+    version: ign-rendering4
   ign-sensors:
     type: git
     url: https://github.com/ignitionrobotics/ign-sensors
-    version: master
+    version: ign-sensors4
   ign-tools:
     type: git
     url: https://github.com/ignitionrobotics/ign-tools
@@ -54,7 +54,7 @@ repositories:
   ign-transport:
     type: git
     url: https://github.com/ignitionrobotics/ign-transport
-    version: master
+    version: ign-transport9
   sdformat:
     type: git
     url: https://github.com/osrf/sdformat

--- a/ign-fuel-tools5.yaml
+++ b/ign-fuel-tools5.yaml
@@ -10,7 +10,7 @@ repositories:
   ign-fuel-tools:
     type: git
     url: https://github.com/ignitionrobotics/ign-fuel-tools
-    version: master
+    version: ign-fuel-tools5
   ign-math:
     type: git
     url: https://github.com/ignitionrobotics/ign-math
@@ -18,7 +18,7 @@ repositories:
   ign-msgs:
     type: git
     url: https://github.com/ignitionrobotics/ign-msgs
-    version: master
+    version: ign-msgs6
   ign-tools:
     type: git
     url: https://github.com/ignitionrobotics/ign-tools

--- a/ign-gazebo4.yaml
+++ b/ign-gazebo4.yaml
@@ -10,15 +10,15 @@ repositories:
   ign-fuel-tools:
     type: git
     url: https://github.com/ignitionrobotics/ign-fuel-tools
-    version: master
+    version: ign-fuel-tools5
   ign-gazebo:
     type: git
     url: https://github.com/ignitionrobotics/ign-gazebo
-    version: master
+    version: ign-gazebo4
   ign-gui:
     type: git
     url: https://github.com/ignitionrobotics/ign-gui
-    version: master
+    version: ign-gui4
   ign-math:
     type: git
     url: https://github.com/ignitionrobotics/ign-math
@@ -26,11 +26,11 @@ repositories:
   ign-msgs:
     type: git
     url: https://github.com/ignitionrobotics/ign-msgs
-    version: master
+    version: ign-msgs4
   ign-physics:
     type: git
     url: https://github.com/ignitionrobotics/ign-physics
-    version: master
+    version: ign-physics3
   ign-plugin:
     type: git
     url: https://github.com/ignitionrobotics/ign-plugin
@@ -38,11 +38,11 @@ repositories:
   ign-rendering:
     type: git
     url: https://github.com/ignitionrobotics/ign-rendering
-    version: master
+    version: ign-rendering4
   ign-sensors:
     type: git
     url: https://github.com/ignitionrobotics/ign-sensors
-    version: master
+    version: ign-sensors4
   ign-tools:
     type: git
     url: https://github.com/ignitionrobotics/ign-tools
@@ -50,7 +50,7 @@ repositories:
   ign-transport:
     type: git
     url: https://github.com/ignitionrobotics/ign-transport
-    version: master
+    version: ign-transport9
   sdformat:
     type: git
     url: https://github.com/osrf/sdformat

--- a/ign-gui4.yaml
+++ b/ign-gui4.yaml
@@ -10,7 +10,7 @@ repositories:
   ign-gui:
     type: git
     url: https://github.com/ignitionrobotics/ign-gui
-    version: master
+    version: ign-gui4
   ign-math:
     type: git
     url: https://github.com/ignitionrobotics/ign-math
@@ -18,7 +18,7 @@ repositories:
   ign-msgs:
     type: git
     url: https://github.com/ignitionrobotics/ign-msgs
-    version: master
+    version: ign-msgs6
   ign-plugin:
     type: git
     url: https://github.com/ignitionrobotics/ign-plugin
@@ -26,7 +26,7 @@ repositories:
   ign-rendering:
     type: git
     url: https://github.com/ignitionrobotics/ign-rendering
-    version: master
+    version: ign-rendering4
   ign-tools:
     type: git
     url: https://github.com/ignitionrobotics/ign-tools
@@ -34,4 +34,4 @@ repositories:
   ign-transport:
     type: git
     url: https://github.com/ignitionrobotics/ign-transport
-    version: master
+    version: ign-transport9

--- a/ign-launch3.yaml
+++ b/ign-launch3.yaml
@@ -10,19 +10,19 @@ repositories:
   ign-fuel-tools:
     type: git
     url: https://github.com/ignitionrobotics/ign-fuel-tools
-    version: master
+    version: ign-fuel-tools5
   ign-gazebo:
     type: git
     url: https://github.com/ignitionrobotics/ign-gazebo
-    version: master
+    version: ign-gazebo4
   ign-gui:
     type: git
     url: https://github.com/ignitionrobotics/ign-gui
-    version: master
+    version: ign-gui4
   ign-launch:
     type: git
     url: https://github.com/ignitionrobotics/ign-launch
-    version: master
+    version: ign-launch3
   ign-math:
     type: git
     url: https://github.com/ignitionrobotics/ign-math
@@ -30,11 +30,11 @@ repositories:
   ign-msgs:
     type: git
     url: https://github.com/ignitionrobotics/ign-msgs
-    version: master
+    version: ign-msgs6
   ign-physics:
     type: git
     url: https://github.com/ignitionrobotics/ign-physics
-    version: master
+    version: ign-physics3
   ign-plugin:
     type: git
     url: https://github.com/ignitionrobotics/ign-plugin
@@ -42,11 +42,11 @@ repositories:
   ign-rendering:
     type: git
     url: https://github.com/ignitionrobotics/ign-rendering
-    version: master
+    version: ign-rendering4
   ign-sensors:
     type: git
     url: https://github.com/ignitionrobotics/ign-sensors
-    version: master
+    version: ign-sensors4
   ign-tools:
     type: git
     url: https://github.com/ignitionrobotics/ign-tools
@@ -54,7 +54,7 @@ repositories:
   ign-transport:
     type: git
     url: https://github.com/ignitionrobotics/ign-transport
-    version: master
+    version: ign-transport9
   sdformat:
     type: git
     url: https://github.com/osrf/sdformat

--- a/ign-msgs6.yaml
+++ b/ign-msgs6.yaml
@@ -10,7 +10,7 @@ repositories:
   ign-msgs:
     type: git
     url: https://github.com/ignitionrobotics/ign-msgs
-    version: master
+    version: ign-msgs6
   ign-tools:
     type: git
     url: https://github.com/ignitionrobotics/ign-tools

--- a/ign-physics3.yaml
+++ b/ign-physics3.yaml
@@ -14,7 +14,7 @@ repositories:
   ign-physics:
     type: git
     url: https://github.com/ignitionrobotics/ign-physics
-    version: master
+    version: ign-physics3
   ign-plugin:
     type: git
     url: https://github.com/ignitionrobotics/ign-plugin

--- a/ign-rendering4.yaml
+++ b/ign-rendering4.yaml
@@ -18,4 +18,4 @@ repositories:
   ign-rendering:
     type: git
     url: https://github.com/ignitionrobotics/ign-rendering
-    version: master
+    version: ign-rendering4

--- a/ign-sensors4.yaml
+++ b/ign-sensors4.yaml
@@ -14,7 +14,7 @@ repositories:
   ign-msgs:
     type: git
     url: https://github.com/ignitionrobotics/ign-msgs
-    version: master
+    version: ign-msgs6
   ign-plugin:
     type: git
     url: https://github.com/ignitionrobotics/ign-plugin
@@ -22,15 +22,15 @@ repositories:
   ign-rendering:
     type: git
     url: https://github.com/ignitionrobotics/ign-rendering
-    version: master
+    version: ign-rendering4
   ign-sensors:
     type: git
     url: https://github.com/ignitionrobotics/ign-sensors
-    version: master
+    version: ign-sensors4
   ign-transport:
     type: git
     url: https://github.com/ignitionrobotics/ign-transport
-    version: master
+    version: ign-transport9
   sdformat:
     type: git
     url: https://github.com/osrf/sdformat

--- a/ign-transport9.yaml
+++ b/ign-transport9.yaml
@@ -10,7 +10,7 @@ repositories:
   ign-msgs:
     type: git
     url: https://github.com/ignitionrobotics/ign-msgs
-    version: master
+    version: ign-msgs6
   ign-tools:
     type: git
     url: https://github.com/ignitionrobotics/ign-tools
@@ -18,4 +18,4 @@ repositories:
   ign-transport:
     type: git
     url: https://github.com/ignitionrobotics/ign-transport
-    version: master
+    version: ign-transport9


### PR DESCRIPTION
Still missing some branches:

- [x] `ign-fuel-tools5`
- [x] `ign-gazebo4`
- [x] `ign-gui4`
- [x] `ign-launch3`
- [x] `ign-msgs6`
- [x] `ign-physics3`
- [x] `ign-rendering4`
- [x] `ign-sensors4`
- [x] `ign-transport9`