### PR TITLE
Add files for new major versions

### DIFF
--- a/ign-fuel-tools6.yaml
+++ b/ign-fuel-tools6.yaml
@@ -1,0 +1,25 @@
+repositories:
+  ign-cmake:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-cmake
+    version: ign-cmake2
+  ign-common:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-common
+    version: ign-common3
+  ign-fuel-tools:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-fuel-tools
+    version: main
+  ign-math:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-math
+    version: ign-math6
+  ign-msgs:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-msgs
+    version: ign-msgs6
+  ign-tools:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-tools
+    version: ign-tools1

--- a/ign-gazebo5.yaml
+++ b/ign-gazebo5.yaml
@@ -1,0 +1,57 @@
+repositories:
+  ign-cmake:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-cmake
+    version: ign-cmake2
+  ign-common:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-common
+    version: ign-common3
+  ign-fuel-tools:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-fuel-tools
+    version: ign-fuel-tools5
+  ign-gazebo:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-gazebo
+    version: main
+  ign-gui:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-gui
+    version: ign-gui4
+  ign-math:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-math
+    version: ign-math6
+  ign-msgs:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-msgs
+    version: ign-msgs4
+  ign-physics:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-physics
+    version: ign-physics3
+  ign-plugin:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-plugin
+    version: ign-plugin1
+  ign-rendering:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-rendering
+    version: ign-rendering4
+  ign-sensors:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-sensors
+    version: ign-sensors4
+  ign-tools:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-tools
+    version: ign-tools1
+  ign-transport:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-transport
+    version: ign-transport9
+  sdformat:
+    type: git
+    url: https://github.com/osrf/sdformat
+    version: sdf10

--- a/ign-gui5.yaml
+++ b/ign-gui5.yaml
@@ -1,0 +1,37 @@
+repositories:
+  ign-cmake:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-cmake
+    version: ign-cmake2
+  ign-common:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-common
+    version: ign-common3
+  ign-gui:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-gui
+    version: main
+  ign-math:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-math
+    version: ign-math6
+  ign-msgs:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-msgs
+    version: ign-msgs6
+  ign-plugin:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-plugin
+    version: ign-plugin1
+  ign-rendering:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-rendering
+    version: ign-rendering4
+  ign-tools:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-tools
+    version: ign-tools1
+  ign-transport:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-transport
+    version: ign-transport9

--- a/ign-launch4.yaml
+++ b/ign-launch4.yaml
@@ -1,0 +1,61 @@
+repositories:
+  ign-cmake:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-cmake
+    version: ign-cmake2
+  ign-common:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-common
+    version: ign-common3
+  ign-fuel-tools:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-fuel-tools
+    version: ign-fuel-tools5
+  ign-gazebo:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-gazebo
+    version: ign-gazebo4
+  ign-gui:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-gui
+    version: ign-gui4
+  ign-launch:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-launch
+    version: main
+  ign-math:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-math
+    version: ign-math6
+  ign-msgs:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-msgs
+    version: ign-msgs6
+  ign-physics:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-physics
+    version: ign-physics3
+  ign-plugin:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-plugin
+    version: ign-plugin1
+  ign-rendering:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-rendering
+    version: ign-rendering4
+  ign-sensors:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-sensors
+    version: ign-sensors4
+  ign-tools:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-tools
+    version: ign-tools1
+  ign-transport:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-transport
+    version: ign-transport9
+  sdformat:
+    type: git
+    url: https://github.com/osrf/sdformat
+    version: sdf10

--- a/ign-msgs7.yaml
+++ b/ign-msgs7.yaml
@@ -1,0 +1,17 @@
+repositories:
+  ign-cmake:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-cmake
+    version: ign-cmake2
+  ign-math:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-math
+    version: ign-math6
+  ign-msgs:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-msgs
+    version: main
+  ign-tools:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-tools
+    version: ign-tools1

--- a/ign-physics4.yaml
+++ b/ign-physics4.yaml
@@ -1,0 +1,25 @@
+repositories:
+  ign-cmake:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-cmake
+    version: ign-cmake2
+  ign-common:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-common
+    version: ign-common3
+  ign-math:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-math
+    version: ign-math6
+  ign-physics:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-physics
+    version: main
+  ign-plugin:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-plugin
+    version: ign-plugin1
+  sdformat:
+    type: git
+    url: https://github.com/osrf/sdformat
+    version: sdf10

--- a/ign-rendering5.yaml
+++ b/ign-rendering5.yaml
@@ -1,0 +1,21 @@
+repositories:
+  ign-cmake:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-cmake
+    version: ign-cmake2
+  ign-common:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-common
+    version: ign-common3
+  ign-math:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-math
+    version: ign-math6
+  ign-plugin:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-plugin
+    version: ign-plugin1
+  ign-rendering:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-rendering
+    version: main

--- a/ign-sensors5.yaml
+++ b/ign-sensors5.yaml
@@ -1,0 +1,37 @@
+repositories:
+  ign-cmake:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-cmake
+    version: ign-cmake2
+  ign-common:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-common
+    version: ign-common3
+  ign-math:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-math
+    version: ign-math6
+  ign-msgs:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-msgs
+    version: ign-msgs6
+  ign-plugin:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-plugin
+    version: ign-plugin1
+  ign-rendering:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-rendering
+    version: ign-rendering4
+  ign-sensors:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-sensors
+    version: main
+  ign-transport:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-transport
+    version: ign-transport9
+  sdformat:
+    type: git
+    url: https://github.com/osrf/sdformat
+    version: sdf10

--- a/ign-transport10.yaml
+++ b/ign-transport10.yaml
@@ -1,0 +1,21 @@
+repositories:
+  ign-cmake:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-cmake
+    version: ign-cmake2
+  ign-math:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-math
+    version: ign-math6
+  ign-msgs:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-msgs
+    version: ign-msgs6
+  ign-tools:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-tools
+    version: ign-tools1
+  ign-transport:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-transport
+    version: main


### PR DESCRIPTION
Each new major version is a copy of the version before it, the only difference being that the library's own branch is `main`.

None of the dependency relationships have changed since Dome. So, for example, `ign-gazebo5`'s dependencies are exactly the same as `ign-gazebo4`'s.