### PR TITLE
ign-gazebo5: depend on ign-utils1

### DIFF
--- a/ign-gazebo5.yaml
+++ b/ign-gazebo5.yaml
@@ -51,6 +51,10 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-transport
     version: main
+  ign-utils:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-utils
+    version: main
   sdformat:
     type: git
     url: https://github.com/osrf/sdformat

--- a/sdformat11.yaml
+++ b/sdformat11.yaml
@@ -3,10 +3,6 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-cmake
     version: ign-cmake2
-  ign-utils:
-    type: git
-    url: https://github.com/ignitionrobotics/ign-utils
-    version: main
   ign-math:
     type: git
     url: https://github.com/ignitionrobotics/ign-math
@@ -15,6 +11,10 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-tools
     version: ign-tools1
+  ign-utils:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-utils
+    version: main
   sdformat:
     type: git
     url: https://github.com/osrf/sdformat


### PR DESCRIPTION
Also updated sdf11 to be in alphabetical order, this makes it easier to compare different yaml files.

Part of https://github.com/ignitionrobotics/ign-gazebo/issues/568