### PR TITLE
Add ign-utils to libsdformat11 dependents

### DIFF
--- a/ign-launch4.yaml
+++ b/ign-launch4.yaml
@@ -55,6 +55,10 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-transport
     version: main
+  ign-utils:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-utils
+    version: main
   sdformat:
     type: git
     url: https://github.com/osrf/sdformat

--- a/ign-physics4.yaml
+++ b/ign-physics4.yaml
@@ -19,6 +19,10 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-plugin
     version: ign-plugin1
+  ign-utils:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-utils
+    version: main
   sdformat:
     type: git
     url: https://github.com/osrf/sdformat

--- a/ign-sensors5.yaml
+++ b/ign-sensors5.yaml
@@ -31,6 +31,10 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-transport
     version: main
+  ign-utils:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-utils
+    version: main
   sdformat:
     type: git
     url: https://github.com/osrf/sdformat


### PR DESCRIPTION
Follow-up to #23, need to add `ign-utils` to dependents of `libsdformat11`.