### PR TITLE
ign-gui5.yaml: add ign-utils

### DIFF
--- a/ign-gui5.yaml
+++ b/ign-gui5.yaml
@@ -35,3 +35,7 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-transport
     version: main
+  ign-utils:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-utils
+    version: main


### PR DESCRIPTION
This is required since ign-transport10 uses ign-utils as of https://github.com/ignitionrobotics/ign-transport/pull/216