### PR TITLE
Add Fortress collection

### DIFF
--- a/collection-fortress.yaml
+++ b/collection-fortress.yaml
@@ -1,0 +1,65 @@
+repositories:
+  ign-cmake:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-cmake
+    version: ign-cmake2
+  ign-common:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-common
+    version: ign-common4
+  ign-fuel-tools:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-fuel-tools
+    version: ign-fuel-tools6
+  ign-gazebo:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-gazebo
+    version: ign-gazebo5
+  ign-gui:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-gui
+    version: ign-gui5
+  ign-launch:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-launch
+    version: ign-launch4
+  ign-math:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-math
+    version: ign-math6
+  ign-msgs:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-msgs
+    version: ign-msgs7
+  ign-physics:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-physics
+    version: ign-physics4
+  ign-plugin:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-plugin
+    version: ign-plugin1
+  ign-rendering:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-rendering
+    version: ign-rendering5
+  ign-sensors:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-sensors
+    version: ign-sensors5
+  ign-tools:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-tools
+    version: ign-tools1
+  ign-transport:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-transport
+    version: ign-transport10
+  ign-utils:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-utils
+    version: ign-utils1
+  sdformat:
+    type: git
+    url: https://github.com/osrf/sdformat
+    version: sdf11


### PR DESCRIPTION
The fortress collection starts as an exact copy of Edifice. As we bump versions this file will have some `main` branches.

https://github.com/ignition-tooling/release-tools/issues/421