### PR TITLE
ign-fuel-tools1.yaml: added to support colcon CI

### DIFF
--- a/ign-fuel-tools1.yaml
+++ b/ign-fuel-tools1.yaml
@@ -1,8 +1,4 @@
 repositories:
-  gazebo:
-    type: git
-    url: https://github.com/osrf/gazebo
-    version: gazebo9
   ign-cmake:
     type: git
     url: https://github.com/ignitionrobotics/ign-cmake
@@ -23,11 +19,3 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-msgs
     version: ign-msgs1
-  ign-transport:
-    type: git
-    url: https://github.com/ignitionrobotics/ign-transport
-    version: ign-transport4
-  sdformat:
-    type: git
-    url: https://github.com/osrf/sdformat
-    version: sdf6


### PR DESCRIPTION
needed for https://github.com/ignition-tooling/release-tools/pull/430

the `ign-common1_colcon` branch is out of date; it's changes are already on `ign-common1`, so I updated the `gazebo9` file as well