### PR TITLE
ign-fuel-tools[67]: add ign-utils1

### DIFF
--- a/ign-fuel-tools6.yaml
+++ b/ign-fuel-tools6.yaml
@@ -23,3 +23,7 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-tools
     version: ign-tools1
+  ign-utils:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-utils
+    version: ign-utils1

--- a/ign-fuel-tools7.yaml
+++ b/ign-fuel-tools7.yaml
@@ -23,3 +23,7 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-tools
     version: ign-tools1
+  ign-utils:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-utils
+    version: ign-utils1


### PR DESCRIPTION
ign-common4 needs ign-utils1 as of https://github.com/ignitionrobotics/ign-common/pull/244

Windows builds are currently broken without this change:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_fuel-tools-ci-win&build=8)](https://build.osrfoundation.org/job/ign_fuel-tools-ci-win/8/) https://build.osrfoundation.org/job/ign_fuel-tools-ci-win/8/