### PR TITLE
Make `ign-math7` depend on `ign-utils`

### DIFF
--- a/ign-math7.yaml
+++ b/ign-math7.yaml
@@ -3,6 +3,10 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-cmake
     version: ign-cmake2
+  ign-utils:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-utils
+    version: ign-utils1
   ign-math:
     type: git
     url: https://github.com/ignitionrobotics/ign-math


### PR DESCRIPTION
In support of multiple enhancements in `ign-math7`, namely:

* https://github.com/ignitionrobotics/ign-math/pull/299 for `ImplPtr`
* https://github.com/ignitionrobotics/ign-math/pull/283 for `NeverDestroyed`

Signed-off-by: Michael Carroll <michael@openrobotics.org>