### PR TITLE
ign-math7 and ign-msgs9 depend on ign-utils

### DIFF
--- a/ign-math7.yaml
+++ b/ign-math7.yaml
@@ -4,11 +4,11 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-cmake
     version: ign-cmake2
-  ign-utils:
-    type: git
-    url: https://github.com/ignitionrobotics/ign-utils
-    version: ign-utils1
   ign-math:
     type: git
     url: https://github.com/ignitionrobotics/ign-math
     version: main
+  ign-utils:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-utils
+    version: ign-utils1

--- a/ign-msgs9.yaml
+++ b/ign-msgs9.yaml
@@ -16,3 +16,7 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-tools
     version: ign-tools1
+  ign-utils:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-utils
+    version: ign-utils1


### PR DESCRIPTION
* Follow up to #64 
* Alphabetize
* Add transient dependency to `ign-msgs9`, see broken build: https://build.osrfoundation.org/job/ign_msgs-pr-win/55/console