### PR TITLE
ign-sensors[6,7] don't depend on ign-plugin

### DIFF
--- a/ign-sensors6.yaml
+++ b/ign-sensors6.yaml
@@ -16,10 +16,6 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-msgs
     version: ign-msgs8
-  ign-plugin:
-    type: git
-    url: https://github.com/ignitionrobotics/ign-plugin
-    version: ign-plugin1
   ign-rendering:
     type: git
     url: https://github.com/ignitionrobotics/ign-rendering

--- a/ign-sensors7.yaml
+++ b/ign-sensors7.yaml
@@ -16,10 +16,6 @@ repositories:
     type: git
     url: https://github.com/ignitionrobotics/ign-msgs
     version: main
-  ign-plugin:
-    type: git
-    url: https://github.com/ignitionrobotics/ign-plugin
-    version: ign-plugin1
   ign-rendering:
     type: git
     url: https://github.com/ignitionrobotics/ign-rendering


### PR DESCRIPTION
The dependency was removed in this PR:

* https://github.com/ignitionrobotics/ign-sensors/pull/90

But we forgot to update gazebodistro.