### PR TITLE
Jetty: use stable branch sdf16

### DIFF
--- a/collection-jetty.yaml
+++ b/collection-jetty.yaml
@@ -63,4 +63,4 @@ repositories:
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat
-    version: main
+    version: sdf16

--- a/gz-launch9.yaml
+++ b/gz-launch9.yaml
@@ -63,4 +63,4 @@ repositories:
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat
-    version: main
+    version: sdf16

--- a/gz-physics9.yaml
+++ b/gz-physics9.yaml
@@ -27,4 +27,4 @@ repositories:
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat
-    version: main
+    version: sdf16

--- a/gz-sensors10.yaml
+++ b/gz-sensors10.yaml
@@ -43,4 +43,4 @@ repositories:
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat
-    version: main
+    version: sdf16

--- a/gz-sim10.yaml
+++ b/gz-sim10.yaml
@@ -59,4 +59,4 @@ repositories:
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat
-    version: main
+    version: sdf16

--- a/sdformat16.yaml
+++ b/sdformat16.yaml
@@ -19,4 +19,4 @@ repositories:
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat
-    version: main
+    version: sdf16


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/26.