### PR TITLE
Use stable branch for gz-launch9

### DIFF
--- a/collection-jetty.yaml
+++ b/collection-jetty.yaml
@@ -23,7 +23,7 @@ repositories:
   gz-launch:
     type: git
     url: https://github.com/gazebosim/gz-launch
-    version: main
+    version: gz-launch9
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-launch9.yaml
+++ b/gz-launch9.yaml
@@ -23,7 +23,7 @@ repositories:
   gz-launch:
     type: git
     url: https://github.com/gazebosim/gz-launch
-    version: main
+    version: gz-launch9
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/18