### PR TITLE
Use vcs2l extend feature in Jetty libs to avoid duplicate declarations

### DIFF
--- a/collection-jetty.yaml
+++ b/collection-jetty.yaml
@@ -1,66 +1,18 @@
 ---
-repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
-  gz-common:
-    type: git
-    url: https://github.com/gazebosim/gz-common
-    version: gz-common7
-  gz-fuel-tools:
-    type: git
-    url: https://github.com/gazebosim/gz-fuel-tools
-    version: gz-fuel-tools11
-  gz-sim:
-    type: git
-    url: https://github.com/gazebosim/gz-sim
-    version: gz-sim10
-  gz-gui:
-    type: git
-    url: https://github.com/gazebosim/gz-gui
-    version: gz-gui10
-  gz-launch:
-    type: git
-    url: https://github.com/gazebosim/gz-launch
-    version: gz-launch9
-  gz-math:
-    type: git
-    url: https://github.com/gazebosim/gz-math
-    version: gz-math9
-  gz-msgs:
-    type: git
-    url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs12
-  gz-physics:
-    type: git
-    url: https://github.com/gazebosim/gz-physics
-    version: gz-physics9
-  gz-plugin:
-    type: git
-    url: https://github.com/gazebosim/gz-plugin
-    version: gz-plugin4
-  gz-rendering:
-    type: git
-    url: https://github.com/gazebosim/gz-rendering
-    version: gz-rendering10
-  gz-sensors:
-    type: git
-    url: https://github.com/gazebosim/gz-sensors
-    version: gz-sensors10
-  gz-tools:
-    type: git
-    url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
-  gz-transport:
-    type: git
-    url: https://github.com/gazebosim/gz-transport
-    version: gz-transport15
-  gz-utils:
-    type: git
-    url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
-  sdformat:
-    type: git
-    url: https://github.com/gazebosim/sdformat
-    version: sdf16
+extends:
+  - gz-cmake5.yaml
+  - gz-utils4.yaml
+  - gz-tools2.yaml
+  - gz-math9.yaml
+  - gz-common7.yaml
+  - gz-plugin4.yaml
+  - gz-msgs12.yaml
+  - sdformat16.yaml
+  - gz-transport15.yaml
+  - gz-rendering10.yaml
+  - gz-physics9.yaml
+  - gz-fuel-tools11.yaml
+  - gz-sensors10.yaml
+  - gz-gui10.yaml
+  - gz-sim10.yaml
+  - gz-launch9.yaml

--- a/gz-common7.yaml
+++ b/gz-common7.yaml
@@ -1,18 +1,11 @@
 ---
+extends:
+  - gz-utils4.yaml
+  - gz-math9.yaml
+  - gz-cmake5.yaml
+
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
     version: gz-common7
-  gz-math:
-    type: git
-    url: https://github.com/gazebosim/gz-math
-    version: gz-math9
-  gz-utils:
-    type: git
-    url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4

--- a/gz-fuel-tools11.yaml
+++ b/gz-fuel-tools11.yaml
@@ -1,30 +1,14 @@
 ---
+extends:
+  - gz-tools2.yaml
+  - gz-common7.yaml
+  - gz-msgs12.yaml
+  - gz-utils4.yaml
+  - gz-math9.yaml
+  - gz-cmake5.yaml
+
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
-  gz-common:
-    type: git
-    url: https://github.com/gazebosim/gz-common
-    version: gz-common7
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools
     version: gz-fuel-tools11
-  gz-math:
-    type: git
-    url: https://github.com/gazebosim/gz-math
-    version: gz-math9
-  gz-msgs:
-    type: git
-    url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs12
-  gz-tools:
-    type: git
-    url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
-  gz-utils:
-    type: git
-    url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4

--- a/gz-gui10.yaml
+++ b/gz-gui10.yaml
@@ -1,42 +1,17 @@
 ---
+extends:
+  - gz-common7.yaml
+  - gz-transport15.yaml
+  - gz-tools2.yaml
+  - gz-rendering10.yaml
+  - gz-utils4.yaml
+  - gz-cmake5.yaml
+  - gz-msgs12.yaml
+  - gz-math9.yaml
+  - gz-plugin4.yaml
+
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
-  gz-common:
-    type: git
-    url: https://github.com/gazebosim/gz-common
-    version: gz-common7
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
     version: gz-gui10
-  gz-math:
-    type: git
-    url: https://github.com/gazebosim/gz-math
-    version: gz-math9
-  gz-msgs:
-    type: git
-    url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs12
-  gz-plugin:
-    type: git
-    url: https://github.com/gazebosim/gz-plugin
-    version: gz-plugin4
-  gz-rendering:
-    type: git
-    url: https://github.com/gazebosim/gz-rendering
-    version: gz-rendering10
-  gz-tools:
-    type: git
-    url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
-  gz-transport:
-    type: git
-    url: https://github.com/gazebosim/gz-transport
-    version: gz-transport15
-  gz-utils:
-    type: git
-    url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4

--- a/gz-launch9.yaml
+++ b/gz-launch9.yaml
@@ -1,66 +1,17 @@
 ---
+extends:
+  - gz-tools2.yaml
+  - gz-gui10.yaml
+  - gz-common7.yaml
+  - gz-transport15.yaml
+  - gz-plugin4.yaml
+  - gz-msgs12.yaml
+  - gz-sim10.yaml
+  - gz-math9.yaml
+  - gz-cmake5.yaml
+
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
-  gz-common:
-    type: git
-    url: https://github.com/gazebosim/gz-common
-    version: gz-common7
-  gz-fuel-tools:
-    type: git
-    url: https://github.com/gazebosim/gz-fuel-tools
-    version: gz-fuel-tools11
-  gz-sim:
-    type: git
-    url: https://github.com/gazebosim/gz-sim
-    version: gz-sim10
-  gz-gui:
-    type: git
-    url: https://github.com/gazebosim/gz-gui
-    version: gz-gui10
   gz-launch:
     type: git
     url: https://github.com/gazebosim/gz-launch
     version: gz-launch9
-  gz-math:
-    type: git
-    url: https://github.com/gazebosim/gz-math
-    version: gz-math9
-  gz-msgs:
-    type: git
-    url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs12
-  gz-physics:
-    type: git
-    url: https://github.com/gazebosim/gz-physics
-    version: gz-physics9
-  gz-plugin:
-    type: git
-    url: https://github.com/gazebosim/gz-plugin
-    version: gz-plugin4
-  gz-rendering:
-    type: git
-    url: https://github.com/gazebosim/gz-rendering
-    version: gz-rendering10
-  gz-sensors:
-    type: git
-    url: https://github.com/gazebosim/gz-sensors
-    version: gz-sensors10
-  gz-tools:
-    type: git
-    url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
-  gz-transport:
-    type: git
-    url: https://github.com/gazebosim/gz-transport
-    version: gz-transport15
-  gz-utils:
-    type: git
-    url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
-  sdformat:
-    type: git
-    url: https://github.com/gazebosim/sdformat
-    version: sdf16

--- a/gz-math9.yaml
+++ b/gz-math9.yaml
@@ -1,14 +1,10 @@
 ---
+extends:
+  - gz-utils4.yaml
+  - gz-cmake5.yaml
+
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
     version: gz-math9
-  gz-utils:
-    type: git
-    url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4

--- a/gz-msgs12.yaml
+++ b/gz-msgs12.yaml
@@ -1,22 +1,11 @@
 ---
+extends:
+  - gz-tools2.yaml
+  - gz-math9.yaml
+  - gz-cmake5.yaml
+
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
-  gz-math:
-    type: git
-    url: https://github.com/gazebosim/gz-math
-    version: gz-math9
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
     version: gz-msgs12
-  gz-tools:
-    type: git
-    url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
-  gz-utils:
-    type: git
-    url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4

--- a/gz-physics9.yaml
+++ b/gz-physics9.yaml
@@ -1,30 +1,14 @@
 ---
+extends:
+  - gz-common7.yaml
+  - sdformat16.yaml
+  - gz-plugin4.yaml
+  - gz-utils4.yaml
+  - gz-math9.yaml
+  - gz-cmake5.yaml
+
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
-  gz-common:
-    type: git
-    url: https://github.com/gazebosim/gz-common
-    version: gz-common7
-  gz-math:
-    type: git
-    url: https://github.com/gazebosim/gz-math
-    version: gz-math9
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
     version: gz-physics9
-  gz-plugin:
-    type: git
-    url: https://github.com/gazebosim/gz-plugin
-    version: gz-plugin4
-  gz-utils:
-    type: git
-    url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
-  sdformat:
-    type: git
-    url: https://github.com/gazebosim/sdformat
-    version: sdf16

--- a/gz-plugin4.yaml
+++ b/gz-plugin4.yaml
@@ -1,18 +1,11 @@
 ---
+extends:
+  - gz-cmake5.yaml
+  - gz-tools2.yaml
+  - gz-utils4.yaml
+
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin
     version: gz-plugin4
-  gz-tools:
-    type: git
-    url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
-  gz-utils:
-    type: git
-    url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4

--- a/gz-rendering10.yaml
+++ b/gz-rendering10.yaml
@@ -1,26 +1,13 @@
 ---
+extends:
+  - gz-common7.yaml
+  - gz-plugin4.yaml
+  - gz-utils4.yaml
+  - gz-math9.yaml
+  - gz-cmake5.yaml
+
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
-  gz-common:
-    type: git
-    url: https://github.com/gazebosim/gz-common
-    version: gz-common7
-  gz-math:
-    type: git
-    url: https://github.com/gazebosim/gz-math
-    version: gz-math9
-  gz-plugin:
-    type: git
-    url: https://github.com/gazebosim/gz-plugin
-    version: gz-plugin4
   gz-rendering:
     type: git
     url: https://github.com/gazebosim/gz-rendering
     version: gz-rendering10
-  gz-utils:
-    type: git
-    url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4

--- a/gz-sensors10.yaml
+++ b/gz-sensors10.yaml
@@ -1,46 +1,16 @@
 ---
+extends:
+  - gz-tools2.yaml
+  - gz-common7.yaml
+  - gz-transport15.yaml
+  - sdformat16.yaml
+  - gz-rendering10.yaml
+  - gz-msgs12.yaml
+  - gz-math9.yaml
+  - gz-cmake5.yaml
+
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
-  gz-common:
-    type: git
-    url: https://github.com/gazebosim/gz-common
-    version: gz-common7
-  gz-math:
-    type: git
-    url: https://github.com/gazebosim/gz-math
-    version: gz-math9
-  gz-msgs:
-    type: git
-    url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs12
-  gz-plugin:
-    type: git
-    url: https://github.com/gazebosim/gz-plugin
-    version: gz-plugin4
-  gz-rendering:
-    type: git
-    url: https://github.com/gazebosim/gz-rendering
-    version: gz-rendering10
   gz-sensors:
     type: git
     url: https://github.com/gazebosim/gz-sensors
     version: gz-sensors10
-  gz-transport:
-    type: git
-    url: https://github.com/gazebosim/gz-transport
-    version: gz-transport15
-  gz-tools:
-    type: git
-    url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
-  gz-utils:
-    type: git
-    url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
-  sdformat:
-    type: git
-    url: https://github.com/gazebosim/sdformat
-    version: sdf16

--- a/gz-sim10.yaml
+++ b/gz-sim10.yaml
@@ -1,62 +1,22 @@
 ---
+extends:
+  - gz-common7.yaml
+  - gz-transport15.yaml
+  - gz-tools2.yaml
+  - gz-rendering10.yaml
+  - gz-utils4.yaml
+  - gz-physics9.yaml
+  - gz-cmake5.yaml
+  - gz-fuel-tools11.yaml
+  - gz-msgs12.yaml
+  - gz-math9.yaml
+  - gz-gui10.yaml
+  - gz-sensors10.yaml
+  - sdformat16.yaml
+  - gz-plugin4.yaml
+
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
-  gz-common:
-    type: git
-    url: https://github.com/gazebosim/gz-common
-    version: gz-common7
-  gz-fuel-tools:
-    type: git
-    url: https://github.com/gazebosim/gz-fuel-tools
-    version: gz-fuel-tools11
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
     version: gz-sim10
-  gz-gui:
-    type: git
-    url: https://github.com/gazebosim/gz-gui
-    version: gz-gui10
-  gz-math:
-    type: git
-    url: https://github.com/gazebosim/gz-math
-    version: gz-math9
-  gz-msgs:
-    type: git
-    url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs12
-  gz-physics:
-    type: git
-    url: https://github.com/gazebosim/gz-physics
-    version: gz-physics9
-  gz-plugin:
-    type: git
-    url: https://github.com/gazebosim/gz-plugin
-    version: gz-plugin4
-  gz-rendering:
-    type: git
-    url: https://github.com/gazebosim/gz-rendering
-    version: gz-rendering10
-  gz-sensors:
-    type: git
-    url: https://github.com/gazebosim/gz-sensors
-    version: gz-sensors10
-  gz-tools:
-    type: git
-    url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
-  gz-transport:
-    type: git
-    url: https://github.com/gazebosim/gz-transport
-    version: gz-transport15
-  gz-utils:
-    type: git
-    url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
-  sdformat:
-    type: git
-    url: https://github.com/gazebosim/sdformat
-    version: sdf16

--- a/gz-tools2.yaml
+++ b/gz-tools2.yaml
@@ -1,9 +1,7 @@
 ---
+extends:
+  - gz-cmake5.yaml
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake3
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools

--- a/gz-transport15.yaml
+++ b/gz-transport15.yaml
@@ -1,26 +1,13 @@
 ---
+extends:
+  - gz-tools2.yaml
+  - gz-utils4.yaml
+  - gz-msgs12.yaml
+  - gz-math9.yaml
+  - gz-cmake5.yaml
+
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
-  gz-math:
-    type: git
-    url: https://github.com/gazebosim/gz-math
-    version: gz-math9
-  gz-msgs:
-    type: git
-    url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs12
-  gz-tools:
-    type: git
-    url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
   gz-transport:
     type: git
     url: https://github.com/gazebosim/gz-transport
     version: gz-transport15
-  gz-utils:
-    type: git
-    url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4

--- a/gz-utils4.yaml
+++ b/gz-utils4.yaml
@@ -1,9 +1,8 @@
 ---
+extends:
+  - gz-cmake5.yaml
+
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils

--- a/sdformat16.yaml
+++ b/sdformat16.yaml
@@ -1,21 +1,11 @@
 ---
+extends:
+  - gz-utils4.yaml
+  - gz-math9.yaml
+  - gz-cmake5.yaml
+  - gz-tools2.yaml
+
 repositories:
-  gz-cmake:
-    type: git
-    url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
-  gz-math:
-    type: git
-    url: https://github.com/gazebosim/gz-math
-    version: gz-math9
-  gz-tools:
-    type: git
-    url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
-  gz-utils:
-    type: git
-    url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat


### PR DESCRIPTION
This is a proof of concept to use github.com/ros-infrastructure/vcs2l/pull/39 extend feature in all the Jetty libraries.

This way the file declare the dependencies as "extend" and only contain one repository information related to the library that is being define :smile: 

We can start moving our infrastructure to replace vcstools by vcs2l but we probably want to keep using the vcstools compatible format by now to give people time to do the migration.