### PR TITLE
Use main branches for all dependencies in Rotary

### DIFF
--- a/collection-rotary.yaml
+++ b/collection-rotary.yaml
@@ -20,10 +20,6 @@ repositories:
     type: git
     url: https://github.com/gazebosim/gz-gui
     version: main
-  gz-launch:
-    type: git
-    url: https://github.com/gazebosim/gz-launch
-    version: main
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-common8.yaml
+++ b/gz-common8.yaml
@@ -2,7 +2,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
+    version: main
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
@@ -10,8 +10,8 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: gz-math9
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
+    version: main

--- a/gz-fuel-tools12.yaml
+++ b/gz-fuel-tools12.yaml
@@ -2,11 +2,11 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
+    version: main
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: gz-common7
+    version: main
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools
@@ -14,16 +14,16 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: gz-math9
+    version: main
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs12
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
+    version: main

--- a/gz-gui11.yaml
+++ b/gz-gui11.yaml
@@ -2,11 +2,11 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
+    version: main
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: gz-common7
+    version: main
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
@@ -14,28 +14,28 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: gz-math9
+    version: main
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs12
+    version: main
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin
-    version: gz-plugin4
+    version: main
   gz-rendering:
     type: git
     url: https://github.com/gazebosim/gz-rendering
-    version: gz-rendering10
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
+    version: main
   gz-transport:
     type: git
     url: https://github.com/gazebosim/gz-transport
-    version: gz-transport15
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
+    version: main

--- a/gz-math10.yaml
+++ b/gz-math10.yaml
@@ -2,7 +2,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
+    version: main
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
@@ -10,4 +10,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
+    version: main

--- a/gz-msgs13.yaml
+++ b/gz-msgs13.yaml
@@ -2,11 +2,11 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
+    version: main
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: gz-math9
+    version: main
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
@@ -14,8 +14,8 @@ repositories:
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
+    version: main

--- a/gz-physics10.yaml
+++ b/gz-physics10.yaml
@@ -2,15 +2,15 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
+    version: main
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: gz-common7
+    version: main
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: gz-math9
+    version: main
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
@@ -18,12 +18,12 @@ repositories:
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin
-    version: gz-plugin4
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
+    version: main
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat
-    version: sdf16
+    version: main

--- a/gz-plugin5.yaml
+++ b/gz-plugin5.yaml
@@ -2,7 +2,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
+    version: main
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin
@@ -10,8 +10,8 @@ repositories:
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
+    version: main

--- a/gz-rendering11.yaml
+++ b/gz-rendering11.yaml
@@ -2,19 +2,19 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
+    version: main
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: gz-common7
+    version: main
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: gz-math9
+    version: main
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin
-    version: gz-plugin4
+    version: main
   gz-rendering:
     type: git
     url: https://github.com/gazebosim/gz-rendering
@@ -22,4 +22,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
+    version: main

--- a/gz-sensors11.yaml
+++ b/gz-sensors11.yaml
@@ -2,27 +2,27 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
+    version: main
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: gz-common7
+    version: main
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: gz-math9
+    version: main
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs12
+    version: main
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin
-    version: gz-plugin4
+    version: main
   gz-rendering:
     type: git
     url: https://github.com/gazebosim/gz-rendering
-    version: gz-rendering10
+    version: main
   gz-sensors:
     type: git
     url: https://github.com/gazebosim/gz-sensors
@@ -30,16 +30,16 @@ repositories:
   gz-transport:
     type: git
     url: https://github.com/gazebosim/gz-transport
-    version: gz-transport15
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
+    version: main
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat
-    version: sdf16
+    version: main

--- a/gz-sim11.yaml
+++ b/gz-sim11.yaml
@@ -2,15 +2,15 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
+    version: main
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: gz-common7
+    version: main
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools
-    version: gz-fuel-tools11
+    version: main
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
@@ -18,44 +18,44 @@ repositories:
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
-    version: gz-gui10
+    version: main
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: gz-math9
+    version: main
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs12
+    version: main
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: gz-physics9
+    version: main
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin
-    version: gz-plugin4
+    version: main
   gz-rendering:
     type: git
     url: https://github.com/gazebosim/gz-rendering
-    version: gz-rendering10
+    version: main
   gz-sensors:
     type: git
     url: https://github.com/gazebosim/gz-sensors
-    version: gz-sensors10
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
+    version: main
   gz-transport:
     type: git
     url: https://github.com/gazebosim/gz-transport
-    version: gz-transport15
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
+    version: main
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat
-    version: sdf16
+    version: main

--- a/gz-tools3.yaml
+++ b/gz-tools3.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools

--- a/gz-transport16.yaml
+++ b/gz-transport16.yaml
@@ -2,19 +2,19 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
+    version: main
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: gz-math9
+    version: main
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs12
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
+    version: main
   gz-transport:
     type: git
     url: https://github.com/gazebosim/gz-transport
@@ -22,4 +22,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
+    version: main

--- a/gz-utils5.yaml
+++ b/gz-utils5.yaml
@@ -2,7 +2,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils

--- a/sdformat17.yaml
+++ b/sdformat17.yaml
@@ -2,19 +2,19 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake5
+    version: main
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: gz-math9
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools
-    version: gz-tools2
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils4
+    version: main
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1446 which is part of https://github.com/gazebo-tooling/release-tools/issues/1403

This also removes gz-launch from collection-rotary.yaml